### PR TITLE
l2cache和Spring Boot集成优化, 文档完善

### DIFF
--- a/l2cache-example/pom.xml
+++ b/l2cache-example/pom.xml
@@ -38,7 +38,7 @@
         <!-- redisson -->
         <dependency>
             <groupId>org.redisson</groupId>
-            <artifactId>redisson</artifactId>
+            <artifactId>redisson-spring-boot-starter</artifactId>
         </dependency>
 
         <!-- kafka -->

--- a/l2cache-example/src/main/java/com/github/jesse/l2cache/example/config/RedissonConfig.java
+++ b/l2cache-example/src/main/java/com/github/jesse/l2cache/example/config/RedissonConfig.java
@@ -3,7 +3,6 @@ package com.github.jesse.l2cache.example.config;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,7 +12,6 @@ import org.springframework.context.annotation.Configuration;
  * @author chenck
  * @date 2020/9/2 14:32
  */
-@RefreshScope
 @Slf4j
 @Configuration
 public class RedissonConfig {

--- a/l2cache-spring-boot-starter/pom.xml
+++ b/l2cache-spring-boot-starter/pom.xml
@@ -20,19 +20,21 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson-spring-boot-starter</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- 使用注释处理器生成自己的元数据 -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
+            <scope>provided</scope>
             <optional>true</optional>
-        </dependency>
-
-        <!-- spring-cloud-context 基于@RefreshScope实现CacheConfig属性的动态刷新 -->
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-context</artifactId>
         </dependency>
 
         <dependency>

--- a/l2cache-spring-boot-starter/src/main/java/com/github/jesse/l2cache/spring/L2CacheProperties.java
+++ b/l2cache-spring-boot-starter/src/main/java/com/github/jesse/l2cache/spring/L2CacheProperties.java
@@ -2,7 +2,6 @@ package com.github.jesse.l2cache.spring;
 
 import com.github.jesse.l2cache.CacheConfig;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
 
 /**
  * 一二级缓存属性配置
@@ -12,7 +11,6 @@ import org.springframework.cloud.context.config.annotation.RefreshScope;
  * @date 2020/4/26 20:44
  */
 @ConfigurationProperties(prefix = "l2cache")
-@RefreshScope
 public class L2CacheProperties {
     /**
      * 缓存配置

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
 
         <!-- dependencies -->
         <spring-boot.version>2.3.0.RELEASE</spring-boot.version>
-        <spring.cloud.version>Greenwich.RELEASE</spring.cloud.version>
         <caffeine.version>2.8.4</caffeine.version>
         <guava.version>32.1.2-jre</guava.version>
         <redisson.version>3.13.0</redisson.version>
@@ -49,15 +48,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- spring-cloud -->
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring.cloud.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
             <dependency>
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
@@ -73,6 +63,12 @@
             <dependency>
                 <groupId>org.redisson</groupId>
                 <artifactId>redisson</artifactId>
+                <version>${redisson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.redisson</groupId>
+                <artifactId>redisson-spring-boot-starter</artifactId>
                 <version>${redisson.version}</version>
             </dependency>
 

--- a/如何使用L2cache.md
+++ b/如何使用L2cache.md
@@ -16,9 +16,10 @@
 </dependency>
 ```
 
-- 常见问题：在项目中引入l2cache后，项目启动失败。
+- 旧版本常见问题：在项目中引入l2cache后，项目启动失败。
 - 原因分析：由于项目和l2cache中依赖的spring相关包版本不一致，导致启动失败。
 - 解决方案：建议排除掉l2cache中的依赖，使用项目中的版本。
+- 新版本已将spring相关依赖的scope设置为provided，避免了依赖冲突问题。
 
 ```xml
 <dependency>
@@ -147,6 +148,46 @@ l2cache:
       # #etcd的地址，如有多个用逗号分隔
       # etcdUrl: http://127.0.0.1:2379
 
+```
+
+**Redisson和Spring集成**
+
+参考: [Integration with Spring - Redisson Reference Guide](https://redisson.org/docs/integration-with-spring/)
+
+可以不指定 `l2cache.config.redis.redissonYamlConfig` 而是使用通用的配置
+
+需要引入 `redisson-spring-boot-starter` 依赖无缝替换掉 `spring-boot-starter-data-redis`
+```xml
+<dependency>
+    <groupId>org.redisson</groupId>
+    <artifactId>redisson-spring-boot-starter</artifactId>
+</dependency>
+<!--注释掉原有的spring-boot-starter-data-redis-->
+<!--
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-data-redis</artifactId>
+</dependency>
+-->
+```
+Spring Boot 2 通用配置
+```yaml
+spring:
+  redis:
+    host: 127.0.0.1
+    port: 6379
+    password:
+    database: 0
+```
+Spring Boot 3 通用配置
+```yaml
+spring:
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+      password:
+      database: 0
 ```
 
 注：


### PR DESCRIPTION
1. 将spring相关依赖的scope设置为provided，避免了依赖冲突问题
2. 新增Redisson和Spring集成文档
3. 去掉Spring Cloud依赖, 配置类会自动刷新, 不需要加@RefreshScope注解